### PR TITLE
add trait for fractal, add setter for request

### DIFF
--- a/src/Filters/QueryFilters.php
+++ b/src/Filters/QueryFilters.php
@@ -70,4 +70,17 @@ abstract class QueryFilters
     {
         return $this->builder;
     }
+
+    /**
+     * Set Request Object
+     *
+     * @param $request
+     * @return $this
+     */
+    public function setRequest($request)
+    {
+        $this->request = $request;
+
+        return $this;
+    }
 }

--- a/src/Traits/Fractal/InteractsWithFractal.php
+++ b/src/Traits/Fractal/InteractsWithFractal.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Deseco\Repositories\Traits\Fractal;
+
+use Illuminate\Http\Request;
+
+trait InteractsWithFractal
+{
+    abstract function map();
+
+    public function transform($filters)
+    {
+        $data = [];
+
+        $map = $this->map();
+
+        foreach($filters as $name => $filter) {
+            $mapItem = $map[$name];
+
+            foreach ($filter as $key => $value) {
+                $data[$mapItem[$key]] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    public function filters()
+    {
+        if($this->request instanceof Request) {
+            return parent::filters();
+        }
+
+        return $this->transform($this->request);
+    }
+}


### PR DESCRIPTION
Add support for fractal transformers
- added trait InteractsWithFractal
- added setter for Request objects

Usage:
1. Use `InteractsWithFractal` trait in filters class
2. Implement `map()` method


